### PR TITLE
Fix import loop (v1.0)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,9 @@
+v1.0.0
+==============================
+* Removed direct import of px-defaults-design module.
+* Added the `$intuit-base-font-size` default variable directly.
+* Updated docs to recommend the `px-defaults-design` module be installed instead of directly installing `px-functions-design`.
+
 v0.3.4
 ==============================
 * Added demo, updated dependencies

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ The functions module contains contains functions that are required for using all
 
 **px-functions-design is a Predix UI CSS module.** You can find a demonstration and full documentation on the [Predix UI catalog](https://predixdev.github.io/predix-ui/?show=px-functions-design&type=css]).
 
+## IMPORT NOTE: It's recommended to install px-defaults-design instead
+
+Rather than install this module directly, it's recommended you install px-defaults-design which includes this module as a dependency. You'll have access to the functions in this module if you install px-defaults-design.
+
+To find installation and import instructions for the px-defaults-design module, see its [Github README](https://github.com/PredixDev/px-defaults-design) or read its [Predix UI catalog documentation page](https://predixdev.github.io/predix-ui/?show=px-defaults-design&type=css).
+
+For more information about this requirement, see this [discussion thread on Github](https://github.com/PredixDev/px-functions-design/pull/2).
+
 ## Install the module
 
 To use the module, you need to install it in your project using Bower. Run this task on the command line from inside your project folder:
@@ -81,5 +89,4 @@ In addition to `triple`, you can use `quarter`, `halve`, `double`, `quadruple`, 
 
 This module depends on the following modules (automatically included with Bower install):
 
-* [px-defaults-design](https://github.com/PredixDev/px-defaults-design)
 * [inuit-functions](https://github.com/inuitcss/tools.functions)

--- a/_tools.functions.scss
+++ b/_tools.functions.scss
@@ -4,8 +4,26 @@
 /// @group px-functions-design
 ////
 
-@import 'px-defaults-design/_settings.defaults.scss';
+//
+// NOTE: As of v1.0.0, importing the `px-functions-design` modules requires that
+// the $intuit-base-font-size variable already be defined.
+//
+// Rather than install the `px-functions-design` directly, it's recommended you
+// install `px-defaults-design` which includes this module as a dependency and
+// automatically defines $intuit-base-font-size. You'll have access to the functions
+// in this module if you install px-defaults-design.
+//
+// For more information, see this discussion in the `px-functions-design` repository
+// on Github: https://github.com/PredixDev/px-functions-design/pull/2
+//
+
 @import 'inuit-functions/_tools.functions.scss';
+
+/// Sets the project-wide base font size. Also used to calculate the base spacing unit. You should set this when you import `px-defaults-design`, but if you consume the functions module directly, you can set it here.
+///
+/// @group px-functions-design:variables:style
+/// @type Number [default]
+$inuit-base-font-size           : 15px !default;
 
 /// Takes a font-size value in pixels and converts it to rem.
 ///

--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,10 @@
 {
   "name": "px-functions-design",
-  "version": "0.3.4",
+  "version": "1.0.0",
   "authors": [
     "General Electric"
   ],
-  "description": "The functions module contains contains functions that are required for using all Predix UI CSS modules. Use it to convert between units (i.e. pixels to REM and back again) and compute numbers.",
+  "description": "The functions module contains contains functions that are required for using all Predix UI CSS modules.",
   "main": "_tools.functions.scss",
   "keywords": [
     "px",
@@ -22,8 +22,7 @@
     "OSS_Notice.pdf"
   ],
   "dependencies": {
-    "inuit-functions": "~0.2.0",
-    "px-defaults-design": "~0.2.12"
+    "inuit-functions": "~0.2.0"
   },
   "devDependencies": {
     "px-starter-kit-design": "~0.6.0",

--- a/index.html
+++ b/index.html
@@ -25,11 +25,20 @@
   layer="tools"
   sassdoc-path="sassdoc.json"
   dependencies='[
-    "https://github.com/PredixDev/px-defaults-design",
     "https://github.com/inuitcss/tools.functions"
   ]'
   hide-demo-container
   selected-options="{{selectedOptions}}">
+
+<section data-slot="intro">
+# IMPORT NOTE: It's recommended to install px-defaults-design instead
+
+Rather than install this module directly, it's recommended you install px-defaults-design which includes this module as a dependency. You'll have access to the functions in this module if you install px-defaults-design.
+
+To find installation and import instructions for the px-defaults-design module, see its [Github README](https://github.com/PredixDev/px-defaults-design) or read its [Predix UI catalog documentation page](https://predixdev.github.io/predix-ui/?show=px-defaults-design&type=css).
+
+For more information about this requirement, see this [discussion thread on Github](https://github.com/PredixDev/px-functions-design/pull/2).
+</section>
 
 <!-- 2: Provide Usage Info -->
 <section data-slot="usage">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "px-functions-design",
-  "version": "0.3.4",
+  "version": "1.0.0",
   "description": "The functions module contains contains functions that are required for using all Predix UI CSS modules. Use it to convert between units (i.e. pixels to REM and back again) and compute numbers.",
   "author": "General Electric",
   "private": false,


### PR DESCRIPTION
# Summary

An unexpected regression was introduced when the px-defaults-design module was updated to new versions of its dependencies. This introduced an import loop that caused downstream consumers of the px-defaults-design module to experience fatal Sass build errors (see #1 and predixdev/px-defaults-design#2).

This major version revision (to the v1 release path) removes the circular dependency but introduces a new requirement: that `$intuit-font-base-size` be defined before this module is imported. More details below.
# What went wrong
1. In February, a [commit to px-functions-design](https://github.com/PredixDev/px-functions-design/commit/cc6f8656958b9cf4ac372646f99a8b4d2f65ee17#diff-999cfeebb604a2d947a3375dad0d021cR7) (cc6f8656958b9cf4ac372646f99a8b4d2f65ee17) added the px-defaults-design repo as a dependency. This created the import loop. Then, px-functions-design was bumped to version `0.3.0`.
2. The px-functions-design module is usually installed as a dependency of px-defaults-design. But the px-defaults-design repository was not updated to install the new version of px-functions-design. The import loop didn't immediately become a problem for downstream users because they never got the new code.
3. This month, [a routine commit to px-defaults-design](https://github.com/PredixDev/px-defaults-design/commit/0d88f1afe0688822c4e9e2cb3a3fa06730bfbf59#diff-0a08a7565aba4405282251491979bb6bR25) updated its dependencies, finally pointing at the problematic February release of px-functions-design that introduced the import loop.
4. Downstream users began to see their Sass builds error out, and reported issues.
# How this fixes it

The px-defaults-design module was initially added as a dependency to functions to ensure a necessary variable would be set defining the default font size (`$intuit-base-font-size`). While this variable wasn't defined in functions before cc6f8656958b9cf4ac372646f99a8b4d2f65ee17, it wasn't an issue because functions was almost always imported by px-defaults-design, which defines the default font size. If functions was imported without defaults, it would have failed the Sass build.

This release removes px-defaults-design as a dependency and instead declares `$intuit-base-font-size` with a default value. This isn't the best thing ever (now we declare the `$intuit-base-font-size` default in two places), but it won't cause any issues because the variable is declared with the `!default` flag and will always be overridden.
# What changes for downstream users

For the most part, nothing. Just update your dependencies for all Predix UI CSS repos and you should see the issue fixed. (Note: it'll take a bit before all Predix UI CSS repos take this update, so watch this thread for more info.) 

However, if you are installing px-functions-design directly, it's recommended to uninstall and install px-defaults-design instead. That way, you'll get all of the functions in this module with your default-font-size declared.
